### PR TITLE
handle the case that failed on curl kube-ps1.sh

### DIFF
--- a/assets/install-kube-ps1-bash
+++ b/assets/install-kube-ps1-bash
@@ -2,10 +2,12 @@
 
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 
-if [ -f ~/.bashrc ] && ! grep -q "kube_ps1" ~/.bashrc; then
-  curl -sLO https://raw.githubusercontent.com/jonmosco/kube-ps1/master/kube-ps1.sh && \
-    chmod +x kube-ps1.sh
+if [ ! -x kube-ps1.sh ]; then
+  curl -sLO https://raw.githubusercontent.com/jonmosco/kube-ps1/master/kube-ps1.sh
+  chmod +x kube-ps1.sh
+fi
 
+if [ -f ~/.bashrc ] && ! grep -q "kube_ps1" ~/.bashrc; then
   cat "${SCRIPT_DIR}/config/bash-kube" >> ~/.bashrc
 fi
 

--- a/assets/install-kube-ps1-zsh
+++ b/assets/install-kube-ps1-zsh
@@ -2,9 +2,11 @@
 
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 
-if [ -f ~/.zshrc ] && ! grep -q "kube_ps1" ~/.zshrc; then
-  curl -sLO https://raw.githubusercontent.com/jonmosco/kube-ps1/master/kube-ps1.sh && \
-    chmod +x kube-ps1.sh
+if [ ! -x kube-ps1.sh ]; then
+  curl -sLO https://raw.githubusercontent.com/jonmosco/kube-ps1/master/kube-ps1.sh
+  chmod +x kube-ps1.sh
+fi
 
+if [ -f ~/.zshrc ] && ! grep -q "kube_ps1" ~/.zshrc; then
   cat "${SCRIPT_DIR}/config/zsh-kube" >> ~/.zshrc
 fi


### PR DESCRIPTION
Hi,

I am Jun Wang, is taking training of apac2 IBM Cloud Native Boot Camp. By following the installation instructions in https://github.com/upslopeio/ibm-cloud-garage-training/blob/main/computer-setup/ibmcloud.md, me and some of classmates ran into a problem that kube-ps1.sh is not installed, even re-run the installation command multiple times.

I found the root cause is that the network is not stable enough for us to fetch file from GitHub, the command below sometimes failed with timeout:
curl -sLO https://raw.githubusercontent.com/jonmosco/kube-ps1/master/kube-ps1.sh

So, when we run https://github.com/cloud-native-toolkit/cloud-shell-commands/blob/main/assets/install-kube-ps1-zsh, the Kubernetes-ps1.sh is not downloaded because time out, but .zshrc is configured, so, when I re-run the installation script, it won't get chance to re-download.

My patch is to separate download file and config .zshrc, so that kube-ps1.sh can get chance to re-download.
The reason I split curl xxx && chmod xxx as two steps, is because one step way won't print anything if failed with time out, whereas my patch can print "chmod: kube-ps1.sh: No such file or directory" in the terminal which is helpful for debugging.

Thanks!
Jun

