### PR TITLE
ICC yq version check fix

### DIFF
--- a/assets/icc
+++ b/assets/icc
@@ -50,7 +50,7 @@ function print_help {
   exit 0
 }
 
-if ! command -v yq 1> /dev/null 2> /dev/null || [[ ! "$(yq --version)" =~ yq.version.4.* ]]; then
+if ! command -v yq 1> /dev/null 2> /dev/null || [[ ! "$(yq --version)" =~ ^yq.*version.4.*$ ]]; then
   echo "yq v4 not found. Follow these instructions to install it - https://mikefarah.gitbook.io/yq/#install"
   exit 1
 fi


### PR DESCRIPTION
At some point output of `yq --version` changed from something like `yq version 4.x.x` to `yq (https://github.com/mikefarah/yq/) version 4.x.x`, so ICC was failing yq version check for latest releases of yq v4.
This commit fixes that.