### PR TITLE
fix: pattern of a cluster name without `/`. issues #904

### DIFF
--- a/assets/config/bash-kube
+++ b/assets/config/bash-kube
@@ -5,7 +5,11 @@ KUBE_PS1_SYMBOL_ENABLE=false
 KUBE_PS1_NS_ENABLE=true
 
 function get_cluster_short() {
-  CLUSTER_NAME=$(echo $1 | awk -F / '{print $2}')
+  if [[ "${1}" =~ "/" ]]; then
+    CLUSTER_NAME=$(echo $1 | awk -F / '{print $2}')
+  else 
+    CLUSTER_NAME=$(echo $1)
+  fi
   SERVER=$(grep -A 1 -B 1 "${CLUSTER_NAME}" ~/.kube/config | grep server | sed -E "s/ *server: (.*)/\1/g")
   NEW_CLUSTER_NAMES=$(grep -A 1 -B 1 "${SERVER}" ~/.kube/config | grep name | grep -v ${CLUSTER_NAME} | sed -E "s/ *name: (.*)/\1/g")
   NEW_CLUSTER_NAME=${NEW_CLUSTER_NAMES%$'\n'*}

--- a/assets/config/zsh-kube
+++ b/assets/config/zsh-kube
@@ -5,7 +5,11 @@ KUBE_PS1_SYMBOL_ENABLE=false
 KUBE_PS1_NS_ENABLE=true
 
 function get_cluster_short() {
-  CLUSTER_NAME=$(echo $1 | awk -F / '{print $2}')
+  if [[ "${1}" =~ "/" ]]; then
+    CLUSTER_NAME=$(echo $1 | awk -F / '{print $2}')
+  else 
+    CLUSTER_NAME=$(echo $1)
+  fi
   SERVER=$(grep -A 1 -B 1 "${CLUSTER_NAME}" ~/.kube/config | grep server | sed -E "s/ *server: (.*)/\1/g")
   NEW_CLUSTER_NAMES=$(grep -A 1 -B 1 "${SERVER}" ~/.kube/config | grep name | grep -v ${CLUSTER_NAME} | sed -E "s/ *name: (.*)/\1/g")
   NEW_CLUSTER_NAME=${NEW_CLUSTER_NAMES%$'\n'*}


### PR DESCRIPTION
Hi,
I fixed a pattern of a cluster name without `/`.  
ref: https://github.com/cloud-native-toolkit/planning/issues/904

## before
<img width="692" alt="スクリーンショット 2022-01-13 20 02 08" src="https://user-images.githubusercontent.com/4592677/149471460-b020dac5-2d91-4067-bcaf-85735b0e5de4.png">

## after
<img width="396" alt="スクリーンショット 2022-01-14 16 54 53" src="https://user-images.githubusercontent.com/4592677/149471469-c4229558-dec8-4abf-beaa-2dfb91cccfc5.png">

